### PR TITLE
Making Sdf2DWorld work with networking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 launchSettings.json
 *.csproj
 *_c
+libsdf/.idea
+libsdf/libsdf.sln

--- a/libsdf/.sbproj
+++ b/libsdf/.sbproj
@@ -8,7 +8,6 @@
   "HasAssets": true,
   "AssetsPath": "",
   "Resources": "/shaders/*.hlsl\n",
-  "MenuResources": null,
   "HasCode": true,
   "CodePath": "/code/",
   "PackageReferences": [

--- a/libsdf/ProjectSettings/Collision.config
+++ b/libsdf/ProjectSettings/Collision.config
@@ -1,0 +1,39 @@
+{
+  "Defaults": {
+    "solid": "Collide",
+    "trigger": "Trigger",
+    "ladder": "Ignore",
+    "water": "Trigger"
+  },
+  "Pairs": [
+    {
+      "a": "solid",
+      "b": "solid",
+      "r": "Collide"
+    },
+    {
+      "a": "trigger",
+      "b": "playerclip",
+      "r": "Ignore"
+    },
+    {
+      "a": "trigger",
+      "b": "solid",
+      "r": "Trigger"
+    },
+    {
+      "a": "solid",
+      "b": "trigger",
+      "r": "Collide"
+    },
+    {
+      "a": "playerclip",
+      "b": "solid",
+      "r": "Collide"
+    }
+  ],
+  "__guid": "cb87b295-60b0-46dc-98ca-1ed35ffff3cb",
+  "__schema": "configdata",
+  "__type": "CollisionRules",
+  "__version": 1
+}

--- a/libsdf/code/2D/Sdf2DChunk.cs
+++ b/libsdf/code/2D/Sdf2DChunk.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sandbox.Sdf;

--- a/libsdf/code/2D/Sdf2DWorld.cs
+++ b/libsdf/code/2D/Sdf2DWorld.cs
@@ -1,5 +1,4 @@
-﻿using Sandbox.Diagnostics;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Sandbox.Sdf;
@@ -20,11 +19,11 @@ public partial class Sdf2DWorld : SdfWorld<Sdf2DWorld, Sdf2DChunk, Sdf2DLayer, (
 		var min = (bounds.TopLeft - quality.MaxDistance - unitSize) / quality.ChunkSize;
 		var max = (bounds.BottomRight + quality.MaxDistance + unitSize) / quality.ChunkSize;
 
-		var minX = (int) MathF.Floor( min.x );
-		var minY = (int) MathF.Floor( min.y );
+		var minX = (int)MathF.Floor( min.x );
+		var minY = (int)MathF.Floor( min.y );
 
-		var maxX = (int) MathF.Ceiling( max.x );
-		var maxY = (int) MathF.Ceiling( max.y );
+		var maxX = (int)MathF.Ceiling( max.x );
+		var maxY = (int)MathF.Ceiling( max.y );
 
 		return (minX, minY, maxX, maxY);
 	}
@@ -35,10 +34,10 @@ public partial class Sdf2DWorld : SdfWorld<Sdf2DWorld, Sdf2DChunk, Sdf2DLayer, (
 		var (minX, minY, maxX, maxY) = GetChunkRange( sdf.Bounds, quality );
 
 		for ( var y = minY; y < maxY; ++y )
-		for ( var x = minX; x < maxX; ++x )
-		{
-			yield return (x, y);
-		}
+			for ( var x = minX; x < maxX; ++x )
+			{
+				yield return (x, y);
+			}
 	}
 
 	protected override bool AffectsChunk<T>( T sdf, WorldQuality quality, (int X, int Y) chunkKey )

--- a/libsdf/code/SdfBroadcasts.cs
+++ b/libsdf/code/SdfBroadcasts.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace Sandbox.Sdf;
+
+/// <summary>
+/// Codegen for Broadcasts on classes with generic types seems to fail,
+/// so this is added as a temporary measure.
+/// </summary>
+public sealed class SdfNetwork : Component
+{
+	[Property] public Sdf2DWorld SdfWorld { get; set; }
+	public static SdfNetwork Instance { get; set; }
+
+	public SdfNetwork()
+	{
+		Instance = this;
+	}
+	
+	[Broadcast]
+	public void SendMeMissing( Guid to, int clearCount, int modificationCount )
+	{
+		if ( Connection.Local != Connection.Host )
+			return;
+
+		var conn = Connection.Find( to );
+		Log.Info( $"Want to send missing to {conn.DisplayName} : {conn.Name} with {clearCount}-{modificationCount}" );
+		SdfWorld.RequestMissing( conn, clearCount, modificationCount );
+	}
+
+	private float _notifiedMissingModifications = float.PositiveInfinity;
+
+	[Broadcast]
+	public void WriteRpc( Guid guid, byte[] bytes )
+	{
+		if ( Connection.Local.Id != guid )
+			return;
+
+		var byteStream = ByteStream.CreateReader( bytes );
+		if ( SdfWorld.Read( ref byteStream ) )
+		{
+			_notifiedMissingModifications = float.PositiveInfinity;
+			return;
+		}
+
+		if ( _notifiedMissingModifications >= 0.5f )
+		{
+			_notifiedMissingModifications = 0f;
+
+			SendMeMissing( Connection.Local.Id, SdfWorld.ClearCount, SdfWorld.ModificationCount );
+		}
+	}
+}

--- a/libsdf/code/SdfChunk.cs
+++ b/libsdf/code/SdfChunk.cs
@@ -353,8 +353,6 @@ public abstract partial class SdfChunk<TWorld, TChunk, TResource, TChunkKey, TAr
 		if ( !Renderer.IsValid() )
 		{
 			Renderer = new SceneObject( Scene.SceneWorld, model );
-			// Renderer = ChunkObject.Components.Create<ModelRenderer>();
-			// Renderer.SceneObject.Position = new Vector3( 256f, 256f, 256f );
 			Renderer.Batchable = Resource.ReferencedTextures is not { Count: > 0 };
 		}
 

--- a/libsdf/code/SdfWorld.Network.cs
+++ b/libsdf/code/SdfWorld.Network.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+
+namespace Sandbox.Sdf;
+
+public partial class SdfWorld<TWorld, TChunk, TResource, TChunkKey, TArray, TSdf> : Component
+{
+	private Dictionary<Connection, ConnectionState> ConnectionStates { get; } = new();
+
+	private record struct ConnectionState( int clearCount, int modificationCount, TimeSince lastMessage );
+
+	private const float HeartbeatPeriod = 2f;
+
+	private void SendModifications( Connection conn )
+	{
+		if ( !ConnectionStates.TryGetValue( conn, out var state ) )
+			state = new ConnectionState( 0, 0, 0f );
+
+		if ( state.clearCount != ClearCount )
+			state = state with { clearCount = ClearCount, modificationCount = 0 };
+		else if ( state.modificationCount >= ModificationCount && state.lastMessage < HeartbeatPeriod )
+			return;
+
+		state = state with { lastMessage = 0f };
+
+		var byteStream = ByteStream.Create( 512 );
+		var count = Write( ref byteStream, state.modificationCount );
+
+		ConnectionStates[conn] = state with { modificationCount = state.modificationCount + count };
+
+		SdfNetwork.Instance.WriteRpc( conn.Id, byteStream.ToArray() );
+		byteStream.Dispose();
+	}
+
+	public void RequestMissing( Connection conn, int clearCount, int modificationCount )
+	{
+		if ( !ConnectionStates.TryGetValue( conn, out var state ) )
+		{
+			Log.Info( $"Can't find connection state for {conn.DisplayName}" );
+			return;
+		}
+
+		if ( state.clearCount != clearCount || state.modificationCount <= modificationCount )
+		{
+			Log.Info( $"Can't do something else" );
+			return;
+		}
+		
+		ConnectionStates[conn] = state with { modificationCount = modificationCount };
+	}
+}

--- a/libsdf/code/SdfWorld.Network.cs
+++ b/libsdf/code/SdfWorld.Network.cs
@@ -39,11 +39,8 @@ public partial class SdfWorld<TWorld, TChunk, TResource, TChunkKey, TArray, TSdf
 			return;
 		}
 
-		if ( state.clearCount != clearCount || state.modificationCount <= modificationCount )
-		{
-			Log.Info( $"Can't do something else" );
+		if (state.clearCount != clearCount || state.modificationCount <= modificationCount)
 			return;
-		}
 		
 		ConnectionStates[conn] = state with { modificationCount = modificationCount };
 	}


### PR DESCRIPTION
Another PR for you to look at if you are interested 👀

- An SdfWorld and all its chunks exist on a single GameObject
- Chunks are _not_  being created per modification, but work as intended and are networked. Modifications are not their own GameObjects, as 1) gameobject iteration is a major pain point in scene right now for performance and 2) it would be overkill for something like Grubs anyway
- Codegen for Broadcast functions seems to be failing for classes with a bunch of generics in the header (didn't really test this extensively) so I created a separate component instead
- SdfChunk uses SceneObject + PhysicsShape instead of components. IMO this is cleaner and more closely mimics the old behaviour anyway. I found I was having a hard time offsetting the chunks with ModelRenderer, as it is written to follow the transform of the parent GameObject. Pol works around this by manually offsetting the vertices.


https://github.com/Facepunch/sbox-sdf/assets/57276947/508475b7-722e-48df-b86a-8575391c9ebb
![image](https://github.com/Facepunch/sbox-sdf/assets/57276947/3cf1e46e-c87c-4d0e-a666-af32e893a207)

